### PR TITLE
add --random-last option to use the seed from the previous run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.03 - Unreleased
+-----------------
+
+* Add --random-last option to use the seed from the previous run.
+  [witsch (Andreas Zeidler)]
+
+
 0.02 - 2013-02-21
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ options:
 * `--random-seed=RANDOM_SEED`
                         the seed to use for randomization if you need to
                         repeat a run.
+* `--random-last`       use the seed from the previous run. this makes it
+                        easier to track down isolation issues.

--- a/random_plugin.py
+++ b/random_plugin.py
@@ -22,10 +22,19 @@ def pytest_addoption(parser):
         type=int,
         default=int(time.time() * 256),
         help="the seed to use for randomization if you need to repeat a run.")
+    group._addoption('--random-last',
+        action="store_true",
+        dest="random_last",
+        default=False,
+        help="use the seed from the previous run.")
 
 
 def pytest_report_header(config):
     if config.option.random:
+        if config.option.random_last:
+            seed = config.cache.get('random/seed', config.option.random_seed)
+            config.option.random_seed = seed
+        config.cache.set('random/seed', config.option.random_seed)
         return "Tests are shuffled using seed number %d." % config.option.random_seed
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import os
 
 
-version = '0.02'
+version = '0.03'
 
 try:  # this block doesn't work under tox
   here = os.path.abspath(os.path.dirname(__file__))
@@ -18,7 +18,7 @@ setup(name='pytest-random',
       author='Leah Klearman',
       author_email='lklrmn@gmail.com',
       url='https://github.com/klrmn/pytest-random',
-      install_requires=['pytest>=2.2.3'],
+      install_requires=['pytest>=2.2.3', 'pytest-cache'],
       py_modules=['random_plugin'],
       entry_points={'pytest11': ['pytest_random = random_plugin']},
       license='Mozilla Public License 2.0 (MPL 2.0)',

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -162,7 +162,7 @@ class TestFunctionality(object):
             indices = dict(
                 [
                     (matcher.search(x).group(1), i)
-                    for i, x in enumerate(actual_output.outlines[6:-2])])
+                    for i, x in enumerate(actual_output.outlines[7:-2])])
             assert abs(indices['test_d'] - indices['test_f']) == 1
         # now run without grouping and check that test_d and test_f can be apart from one another
         gathered_indices = set()
@@ -172,6 +172,6 @@ class TestFunctionality(object):
             indices = dict(
                 [
                     (matcher.search(x).group(1), i)
-                    for i, x in enumerate(actual_output.outlines[6:-2])])
+                    for i, x in enumerate(actual_output.outlines[7:-2])])
             gathered_indices.add(abs(indices['test_d'] - indices['test_f']))
         assert gathered_indices != set([1])

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -159,19 +159,21 @@ class TestFunctionality(object):
         for x in range(5):
             actual_output = testdir.runpytest('--random', '--random-group', '--verbose')
             assert actual_output.outlines[6:-1] != self.expected_output.outlines[6:-1]
+            matches = filter(None, map(matcher.search, actual_output.outlines))
             indices = dict(
                 [
-                    (matcher.search(x).group(1), i)
-                    for i, x in enumerate(actual_output.outlines[7:-2])])
+                    (match.group(1), i)
+                    for i, match in enumerate(matches)])
             assert abs(indices['test_d'] - indices['test_f']) == 1
         # now run without grouping and check that test_d and test_f can be apart from one another
         gathered_indices = set()
         for x in range(5):
             actual_output = testdir.runpytest('--random', '--verbose')
             assert actual_output.outlines[6:-1] != self.expected_output.outlines[6:-1]
+            matches = filter(None, map(matcher.search, actual_output.outlines))
             indices = dict(
                 [
-                    (matcher.search(x).group(1), i)
-                    for i, x in enumerate(actual_output.outlines[7:-2])])
+                    (match.group(1), i)
+                    for i, match in enumerate(matches)])
             gathered_indices.add(abs(indices['test_d'] - indices['test_f']))
         assert gathered_indices != set([1])

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -147,6 +147,21 @@ class TestFunctionality(object):
         assert first_output.outlines[6:-1] != third_output.outlines[6:-1]
 
 
+    def test_last_seed_is_reused(self, testdir):
+        # set up prereqs
+        self._set_things_up(testdir)
+
+        # do randomized run
+        first_run = testdir.runpytest('--random', '--verbose')
+        first_output = [line for line in first_run.outlines
+            if line.startswith(u'Tests are shuffled')]
+        # second run should be the same order
+        second_run = testdir.runpytest('--random', '--random-last', '--verbose')
+        second_output = [line for line in second_run.outlines
+            if line.startswith(u'Tests are shuffled')]
+        assert first_output == second_output
+
+
     # fixtures are in version 2.3 onward
     @pytest.mark.skipif("pytest.__version__ < '2.3'")
     def test_group_by_fixture(self, testdir):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
 recreate=True
 sitepackages=False
 commands =
-    {envbindir}/py.test . {posargs}
+    {envbindir}/py.test tests/ {posargs}
 
 # ENVIRONMENT MATRIX
 # python versions 2.6, 2.7


### PR DESCRIPTION
this should make it easier to track down isolation issues...

note that this already includes https://github.com/klrmn/pytest-random/pull/4
